### PR TITLE
ci: upgrade action runtime to node24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dylanvann/publish-github-action@v1.1.49
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run yarn-deduplicate --fail --strategy fewer

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.
 runs:
-  using: node16
+  using: node24
   main: dist/index.js
 branding:
   icon: unlock


### PR DESCRIPTION
## Summary
- Updates `action.yml` to use `runs.using: node24` (from `node16`)
- Updates CI workflow actions (`actions/checkout@v6`, `actions/setup-node@v4`, node 24)
- No dist rebuild needed — existing bundle is plain JS and runs fine on Node 24

Fixes kingstreetlabs/KingStreetLabs#18381

## Context
GitHub runners are defaulting to Node 24 on June 16, 2026. This update declares the action as natively Node 24 compatible, eliminating deprecation warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)